### PR TITLE
Failing edge case tests

### DIFF
--- a/test/typohero_test.rb
+++ b/test/typohero_test.rb
@@ -181,6 +181,7 @@ multiline
   def test_should_not_break_caps_with_apostrophes
     assert_enhance "JIMMY'S", '<span class="caps">JIMMY&#8217;S</span>'
     assert_enhance "<i>D.O.T.</i>HE34T<b>RFID</b>", '<i><span class="caps">D.O.T.</span></i><span class="caps">HE34T</span><b><span class="caps">RFID</span></b>'
+    assert_enhance 'D.O.T.S. or NOT.', '<span class="caps">D.O.T.S.</span> or <span class="caps">NOT</span>.'
   end
 
   def test_should_not_break_caps_with_ampersands

--- a/test/typohero_test.rb
+++ b/test/typohero_test.rb
@@ -153,6 +153,7 @@ multiline
     assert_enhance 'One &amp; two', 'One <span class="amp">&amp;</span>&nbsp;two'
     assert_enhance 'One &#38; two', 'One <span class="amp">&amp;</span>&nbsp;two'
     assert_enhance 'One&nbsp;&amp;&nbsp;two', 'One&nbsp;<span class="amp">&amp;</span>&nbsp;two'
+    assert_enhance '(& what)', '(<span class="amp">&amp;</span>&nbsp;what)'
   end
 
   def test_should_ignore_special_amps

--- a/test/typohero_test.rb
+++ b/test/typohero_test.rb
@@ -161,11 +161,15 @@ multiline
   end
 
   def test_should_replace_caps
-    assert_enhance "A message from KU", 'A message from&nbsp;<span class="caps">KU</span>'
     assert_enhance "DG-1000", '<span class="caps"><span class="nobr">DG-1000</span></span>'
-    assert_enhance 'Replace text <a href=".">IN</a> tags', 'Replace text <a href="."><span class="caps">IN</span></a>&nbsp;tags'
-    assert_enhance 'Replace text <i>IN</i> tags', 'Replace text <i><span class="caps">IN</span></i>&nbsp;tags'
-    assert_enhance 'AB, CD, EF', '<span class="caps">AB</span>, <span class="caps">CD</span>,&nbsp;<span class="caps">EF</span>'
+    assert_enhance 'Replace text <a href=".">INSIDE</a> tags', 'Replace text <a href="."><span class="caps">INSIDE</span></a>&nbsp;tags'
+    assert_enhance 'Replace text <i>INSIDE</i> tags', 'Replace text <i><span class="caps">INSIDE</span></i>&nbsp;tags'
+    assert_enhance 'ABC, DEF, GHI', '<span class="caps">ABC</span>, <span class="caps">DEF</span>,&nbsp;<span class="caps">GHI</span>'
+  end
+
+  def test_should_only_replace_three_or_more_caps
+    assert_enhance "A message from KU", 'A message from&nbsp;KU'
+    assert_enhance 'AB, CD, EF', 'AB, CD,&nbsp;EF'
   end
 
   def test_should_ignore_special_case_caps

--- a/test/typohero_test.rb
+++ b/test/typohero_test.rb
@@ -166,6 +166,7 @@ multiline
     assert_enhance 'Replace text <a href=".">INSIDE</a> tags', 'Replace text <a href="."><span class="caps">INSIDE</span></a>&nbsp;tags'
     assert_enhance 'Replace text <i>INSIDE</i> tags', 'Replace text <i><span class="caps">INSIDE</span></i>&nbsp;tags'
     assert_enhance 'ABC, DEF, GHI', '<span class="caps">ABC</span>, <span class="caps">DEF</span>,&nbsp;<span class="caps">GHI</span>'
+    assert_enhance 'HTML/XHTML', '<span class="caps">HTML</span>/<span class="caps">XHTML</span>'
   end
 
   def test_should_only_replace_three_or_more_caps

--- a/test/typohero_test.rb
+++ b/test/typohero_test.rb
@@ -167,6 +167,7 @@ multiline
     assert_enhance 'Replace text <i>INSIDE</i> tags', 'Replace text <i><span class="caps">INSIDE</span></i>&nbsp;tags'
     assert_enhance 'ABC, DEF, GHI', '<span class="caps">ABC</span>, <span class="caps">DEF</span>,&nbsp;<span class="caps">GHI</span>'
     assert_enhance 'HTML/XHTML', '<span class="caps">HTML</span>/<span class="caps">XHTML</span>'
+    assert_enhance 'UNDERSCORE_DELIMITED_CAPS', '<span class="caps">UNDERSCORE_DELIMITED_CAPS</span>'
   end
 
   def test_should_only_replace_three_or_more_caps

--- a/test/typohero_test.rb
+++ b/test/typohero_test.rb
@@ -168,6 +168,8 @@ multiline
     assert_enhance 'ABC, DEF, GHI', '<span class="caps">ABC</span>, <span class="caps">DEF</span>,&nbsp;<span class="caps">GHI</span>'
     assert_enhance 'HTML/XHTML', '<span class="caps">HTML</span>/<span class="caps">XHTML</span>'
     assert_enhance 'UNDERSCORE_DELIMITED_CAPS', '<span class="caps">UNDERSCORE_DELIMITED_CAPS</span>'
+    assert_enhance '(WHEEE)', '(<span class="caps">WHEEE</span>)'
+    assert_enhance '&#8220;WHEEE&#8221;', '<span class="dquo">&#8220;</span><span class="caps">WHEEE</span>&#8221;'
   end
 
   def test_should_only_replace_three_or_more_caps


### PR DESCRIPTION
- [x] Don't include trailing periods in caps spans: `<span class="caps">HOT</span>.`
- [x] Require three letters in a row before wrapping in `<span class="caps">`.
- [ ] Don't insert a hairspace around em dashes when the dash isn't between words (and doesn't already have a space): `<p>— John Updike</p>` => `<p> — John Updike</p>`
- [ ] **??** Don't ruin existing non-space whitespace: `<p>foo<br>\n…</p>` into `<p>foo<br> …</p>`
- [x] The ampersand in `(& what)` doesn't get an `amp` span.
- [ ] It seems to be forgetting the `<span class="dquo">` on curley quotes at the start of `<h1>` tags some of the time — and maybe other headings?
- [x] ~~Missing caps span in `HTML/XHTML`.~~
- [x] ~~Ensure caps inside parens and quotes get spans: `foo (BAR) baz` and `“QUX”`~~
- [x] ~~Also, `Underscore delimited caps strings <span class="caps">ARE</span>_A_BIT_WEIRD` :)~~
- ~~Wrap parts of words when there's a mixed caps word, like `No<span class="caps">SQL</span>`~~

Failing test cases for #2  
