### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ TypoHero.strip_tags('Text with tags...')
   * Widon't with Unicode non-breaking space
   * Skips special tags like `<script>`
   * Styling enhancements
-    * Captial letters are wrapped in `<span class="caps">`
+    * Capital letters are wrapped in `<span class="caps">`
     * Initial quotes are wrapped in `<span class="quo">`
     * Ampersands are wrapped in `<span class="amp">`
     * Ordinals are wrapped in `<span class="ord">`


### PR DESCRIPTION
@minad, I've corrected a typographical error in the documentation of the [typohero](https://github.com/minad/typohero) project. Specifically, I've changed captial to capital. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
